### PR TITLE
Fix typo in static grating phase explanation

### DIFF
--- a/databook/visual-coding-2p/vc2p-stimuli.md
+++ b/databook/visual-coding-2p/vc2p-stimuli.md
@@ -151,7 +151,7 @@ print("phases: ", np.sort(static_gratings_table.phase.dropna().unique()))
 
 ```{admonition} What is the phase of the grating?
 :class: tip
-The phase refers to the relative position of the grating. Phase 0 and Phase 0.5 are 180° apart so that the peak of the grating of phase 0 lines up with the rought of phase 0.5.
+The phase refers to the relative position of the grating. Phase 0 and Phase 0.5 are 180° apart so that the peak of the grating of phase 0 lines up with the trough of phase 0.5.
 
 ![phase](/resources/phase_figure_2.png)
 ```


### PR DESCRIPTION
Just caught this while working on improving the metadata of the [visual coding ophys dataset on DANDI](https://dandiarchive.org/dandiset/000728/draft)