### PR TITLE
Fix stimulus presentation errors

### DIFF
--- a/databook/physiology/ophys/visual-behavior/VB-BehaviorSessionData.md
+++ b/databook/physiology/ophys/visual-behavior/VB-BehaviorSessionData.md
@@ -271,7 +271,7 @@ First, add a column to the stimulus_presentations table that assigns a unique co
 ```{code-cell} ipython3
 unique_stimuli = [stimulus for stimulus in behavior_session.stimulus_presentations['image_name'].unique()]
 colormap = {image_name: sns.color_palette()[image_number] for image_number, image_name in enumerate(np.sort(unique_stimuli))}
-behavior_session._stimuli._presentations.value['color'] = behavior_session.stimulus_presentations['image_name'].map(lambda image_name: colormap[image_name])
+behavior_session._stimuli._presentations.value['color'] = behavior_session.stimulus_presentations['image_name'].map(lambda image_name: colormap[str(image_name)])
 ```
 
 Now make some simple plotting functions to plot these datastreams

--- a/databook/physiology/ophys/visual-behavior/VBO-ExperimentData.md
+++ b/databook/physiology/ophys/visual-behavior/VBO-ExperimentData.md
@@ -792,7 +792,7 @@ colormap['omitted'] = (1,1,1) # set omitted stimulus to white color
 
 # add the colors for each image to the stimulus presentations table in the dataset
 stimulus_presentations = ophys_experiment.stimulus_presentations
-stimulus_presentations['color'] = ophys_experiment.stimulus_presentations['image_name'].map(lambda image_name: colormap[image_name])
+stimulus_presentations['color'] = ophys_experiment.stimulus_presentations['image_name'].map(lambda image_name: colormap[str(image_name)])
 ```
 
 Here are some plotting functions for convenience.
@@ -914,7 +914,7 @@ colormap = {image_name: sns.color_palette()[image_number] for image_number, imag
 colormap['omitted'] = (1,1,1)
 
 # add the colors for each image to the stimulus presentations table in the dataset
-ophys_experiment.stimulus_presentations['color'] = ophys_experiment.stimulus_presentations['image_name'].map(lambda image_name: colormap[image_name])
+ophys_experiment.stimulus_presentations['color'] = ophys_experiment.stimulus_presentations['image_name'].map(lambda image_name: colormap[str(image_name)])
 ```
 
 ```{code-cell} ipython3

--- a/databook/physiology/ophys/visual-behavior/VBO-Tutorial-Compare_trial_types.md
+++ b/databook/physiology/ophys/visual-behavior/VBO-Tutorial-Compare_trial_types.md
@@ -246,7 +246,7 @@ def add_image_colors(stimulus_presentations):
     colormap = {image_name: sns.color_palette()[image_number] for image_number, image_name in enumerate(np.sort(unique_stimuli))}
     colormap['omitted'] = [1, 1, 1] # assign white to omitted
     # add color column to stimulus presentations
-    stimulus_presentations['color'] = stimulus_presentations['image_name'].map(lambda image_name: colormap[image_name])
+    stimulus_presentations['color'] = stimulus_presentations['image_name'].map(lambda image_name: colormap[str(image_name)])
     return stimulus_presentations
 
 


### PR DESCRIPTION
Fix #84 

When sorting an array of strings, NumPy turns NaN floats into the string 'nan'. This breaks the map from `stimulus_presentation['image_name']` since that column still has the NaN values. So we cast those values to a string.