### PR TITLE
Fix response latency calculation

### DIFF
--- a/databook/physiology/ephys/visual-behavior/VBN-Tutorial-Aligning_Behavior_Data_to_Task_Events.md
+++ b/databook/physiology/ephys/visual-behavior/VBN-Tutorial-Aligning_Behavior_Data_to_Task_Events.md
@@ -313,8 +313,12 @@ def get_change_time_from_stim_table(row):
     if np.isnan(change_frame):
         return np.nan
 
-    change_time = table[table.start_frame==change_frame]\
-                    ['start_time'].values[0]
+    change_times = table[table.start_frame==change_frame]['start_time'].values
+
+    if len(change_times) == 0:
+        return np.nan
+    else:
+        return change_times[0]
 
     return change_time
 


### PR DESCRIPTION
We get the time at which the stimulus presentation changes from `stimulus_presentations`. But if no rows are returned from the table when we join on change frame, the list of rows are empty, so indexing is impossible, and we were getting an indexing error.

Now if no rows are returned we just return NaN.

Fixes #88 .