### PR TITLE
Add CTLUT kernel

### DIFF
--- a/databook/physiology/ephys/cell-type-lookup-table/ctlut-accessing-data.md
+++ b/databook/physiology/ephys/cell-type-lookup-table/ctlut-accessing-data.md
@@ -6,9 +6,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.15.0
 kernelspec:
-  display_name: allensdk
+  display_name: ctlut
   language: python
-  name: allensdk
+  name: ctlut
 ---
 
 # Accessing cell type lookup table data

--- a/databook/physiology/ephys/cell-type-lookup-table/ctlut-identifying-tagged-units.md
+++ b/databook/physiology/ephys/cell-type-lookup-table/ctlut-identifying-tagged-units.md
@@ -6,9 +6,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.15.0
 kernelspec:
-  display_name: allensdk
+  display_name: ctlut
   language: python
-  name: allensdk
+  name: ctlut
 ---
 
 # Identifying tagged neurons

--- a/databook/physiology/ephys/cell-type-lookup-table/ctlut-optotagging.md
+++ b/databook/physiology/ephys/cell-type-lookup-table/ctlut-optotagging.md
@@ -6,9 +6,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.14.7
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: ctlut
   language: python
-  name: allensdk
+  name: ctlut
 ---
 
 # Optotagging


### PR DESCRIPTION
Separate the ipython kernel for the CTLUT pages from the kernel running the rest of the pages. The reason is that the CTLUT pages use a package called `hdmf-zarr` which depends on packages `hdmf` and `numpy`. The allensdk also depends on these packages, but different versions, creating a dependency conflict. Separating the environments has been the only solution that has worked so far. I could experiment with other permutations of package versions, but that will take more time.

Note that in order for this to work, this change also needs a different version of the build process. The updated build capsule is here: https://codeocean.allenneuraldynamics.org/capsule/3064024/tree