### PR TITLE
Overview links

### DIFF
--- a/databook/glossary.md
+++ b/databook/glossary.md
@@ -136,7 +136,7 @@ Neuropixels
   and the Allen Institute. These devices utilize modern integrated circuit
   design to miniaturize aspects of electrophysiology, enabling recordings of
   hundred of single units from a single probe with minimal brain damage.
-  {cite:t}`jun2017` describes these probes.
+  {cite:t}`jun2017` describes these probes; a summary can also be found [here](neuropixels-description).
 
 Ophys
   Shorthand for optical physiology, often in reference to {term}`Two-photon calcium imaging`.

--- a/databook/physiology/ephys/ephys-overview.md
+++ b/databook/physiology/ephys/ephys-overview.md
@@ -1,18 +1,17 @@
 # Ephys
 
 This section contains information about the electrophysiology datasets. These datasets
-were collected using high-density extracellular electrophysiology probes called [Neuropixels probes](neuropixels-description). 
+were collected using high-density [extracellular electrophysiology](Neuropixels-electrophysiology) probes called [Neuropixels probes](neuropixels-description). 
 
 ## Visual Coding
 
-The [Visual Coding – Neuropixels](vcnp) dataset uses six Neuropixels probes to record spikes from
+The [Visual Coding – Neuropixels](vcnp) dataset uses six Neuropixels probes to record {term}`spike`s from
 a wide variety of regions in the mouse brain. Our experiments were specifically designed to
-study the activity of the visual cortex and thalamus in the context of passive visual
-stimulation. 
+study the activity of the visual cortex and thalamus in the context of [passive visual stimulation](visual-stimuli-list). 
 
 ## Visual Behavior
 
-The [Visual Behavior – Neuropixels](VB-Neuropixels) dataset consists of electrophysiological recordings of neural activity in mice performing a visual change detection task. Each experiment includes data from up to six Neuropixels probes recording simultaneously in cortex, hippocampus, thalamus and midbrain, while mice were exposed to different sensory and behavioral contexts, including familiar and novel stimuli, as well as active and passive stimulus blocks.
+The [Visual Behavior – Neuropixels](VB-Neuropixels) dataset consists of electrophysiological recordings of neural activity in mice performing a visual [change detection task](change_detection_task). Each experiment includes data from up to six Neuropixels probes recording simultaneously in cortex, hippocampus, thalamus and midbrain, while mice were exposed to different sensory and behavioral contexts, including familiar and novel stimuli, as well as active and passive stimulus blocks.
 
 ## Cell Type Look-Up Table
 

--- a/databook/physiology/ephys/ephys-overview.md
+++ b/databook/physiology/ephys/ephys-overview.md
@@ -1,19 +1,19 @@
 # Ephys
 
 This section contains information about the electrophysiology datasets. These datasets
-were collected using high-density extracellular electrophysiology probes called Neuropixels probes. 
+were collected using high-density extracellular electrophysiology probes called [Neuropixels probes](neuropixels-description). 
 
 ## Visual Coding
 
-The Visual Coding – Neuropixels dataset uses six Neuropixels probes to record spikes from
+The [Visual Coding – Neuropixels](vcnp) dataset uses six Neuropixels probes to record spikes from
 a wide variety of regions in the mouse brain. Our experiments were specifically designed to
 study the activity of the visual cortex and thalamus in the context of passive visual
 stimulation. 
 
 ## Visual Behavior
 
-The Visual Behavior Neuropixels dataset consists of electrophysiological recordings of neural activity in mice performing a visual change detection task. Each experiment includes data from up to six Neuropixels probes recording simultaneously in cortex, hippocampus, thalamus and midbrain, while mice were exposed to different sensory and behavioral contexts, including familiar and novel stimuli, as well as active and passive stimulus blocks.
+The [Visual Behavior – Neuropixels](VB-Neuropixels) dataset consists of electrophysiological recordings of neural activity in mice performing a visual change detection task. Each experiment includes data from up to six Neuropixels probes recording simultaneously in cortex, hippocampus, thalamus and midbrain, while mice were exposed to different sensory and behavioral contexts, including familiar and novel stimuli, as well as active and passive stimulus blocks.
 
 ## Cell Type Look-Up Table
 
-The cell type look-up table dataset is a collection of recordings taken from the mouse striatum with the goal of collecting a ground truth data set detailing the responses of different striatal cell types.
+The [cell type look-up table](ctlut-background) dataset is a collection of recordings taken from the mouse striatum with the goal of collecting a ground truth data set detailing the responses of different striatal cell types.

--- a/databook/physiology/ophys/ophys-overview.md
+++ b/databook/physiology/ophys/ophys-overview.md
@@ -11,7 +11,7 @@ The [Visual Coding 2-photon](vc2p-background) dataset is a survey of in vivo phy
 in the awake mouse visual cortex. We collected data across six different visual cortical
 areas, including {term}`V1` and five {term}`HVA`s, using 14 {term}`Transgenic line`s, and
 across the cortical layers. During imaging, mice were awake, head-fixed under the microscope
-and positioned on a running disk that enabled them to run at will (see {doc}`experimental-setup`)). The mice passively viewed an assortment of visual stimuli {doc}`vc2p-stimuli` presented on a monitor. 
+and positioned on a running disk that enabled them to run at will (see {doc}`experimental-setup`). The mice passively viewed an assortment of visual stimuli {doc}`vc2p-stimuli` presented on a monitor. 
 
 ## Visual Behavior
 

--- a/databook/physiology/ophys/ophys-overview.md
+++ b/databook/physiology/ophys/ophys-overview.md
@@ -7,7 +7,7 @@ specific population of neurons.
 
 ## Visual Coding
 
-The Visual Coding 2-photon dataset is a survey of in vivo physiological activity
+The [Visual Coding 2-photon](vc2p-background) dataset is a survey of in vivo physiological activity
 in the awake mouse visual cortex. We collected data across six different visual cortical
 areas, including {term}`V1` and five {term}`HVA`s, using 14 {term}`Transgenic line`s, and
 across the cortical layers. During imaging, mice were awake, head-fixed under the microscope
@@ -15,4 +15,4 @@ and positioned on a running disk that enabled them to run at will (see {doc}`exp
 
 ## Visual Behavior
 
-The Visual Behavior Ophys dataset measured the activity of genetically identified neurons in the visual cortex of mice performing a go/no-go visual [Change Detection Task](change_detection_task). The same population of neurons was recorded over multiple days with varying sensory and behavioral contexts, including familiar and novel stimuli, and passive exposure sessions. This dataset can be used to evaluate the influence of experience, expectation, and task engagement on neural coding and dynamics in excitatory and inhibitory cell populations. 
+The [Visual Behavior Ophys](VB-Ophys) dataset measured the activity of genetically identified neurons in the visual cortex of mice performing a go/no-go visual [Change Detection Task](change_detection_task). The same population of neurons was recorded over multiple days with varying sensory and behavioral contexts, including familiar and novel stimuli, and passive exposure sessions. This dataset can be used to evaluate the influence of experience, expectation, and task engagement on neural coding and dynamics in excitatory and inhibitory cell populations. 


### PR DESCRIPTION
Connects overview pages with a variety of other pages where applicable. Also adds a link to glossary directing to Neuropixels description page for more details.

resolves Issue #104 