### PR TITLE
Kernel change

### DIFF
--- a/databook/physiology/pyNWB/pyNWB.md
+++ b/databook/physiology/pyNWB/pyNWB.md
@@ -8,7 +8,7 @@ jupytext:
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
-  name: allensdk
+  name: ctlut
 ---
 
 # Using Python to Access Neurodata Without Borders-type Files


### PR DESCRIPTION
Somehow the kernel for the pyNWB tutorial got changed back to the wrong one somewhere along the way. Changes it back to the correct kernel with hdmf-zarr.