### PR TITLE
Terminate figure in `scm-background.md`

### DIFF
--- a/databook/_toc.yml
+++ b/databook/_toc.yml
@@ -102,7 +102,10 @@ parts:
         - file: anatomy/microns-em/em-functional_data.md
         - file: anatomy/microns-em/em-coordinates.md
         - file: anatomy/microns-em/em-ultrastructure.md
-      - file: anatomy/single-cell-morphology/scm-background                    # Also a placeholder that needs actual content
+      - file: anatomy/single-cell-morphology/scm-background
+        sections:
+        -  file: anatomy/single-cell-morphology/scm-data.md
+        -  file: anatomy/single-cell-morphology/scm-imageprocessing.md
   - caption: Computational Tools
     chapters:
     - file: computational/data-analysis/data-analysis.md

--- a/databook/anatomy/single-cell-morphology/scm-background.md
+++ b/databook/anatomy/single-cell-morphology/scm-background.md
@@ -18,6 +18,7 @@ kernelspec:
 ---
 align: center
 ---
+:::
 
 ## Background
 


### PR DESCRIPTION
The figure block at the top of the page wasn't closed, so the rest of
the page was gobbled by the figure block, preventing it from rendering.

Fixes #121