### PR TITLE
Remove 'TO DO: NEEDS FIGURES' from description

### DIFF
--- a/databook/background/neuropixels-description.md
+++ b/databook/background/neuropixels-description.md
@@ -1,7 +1,5 @@
 # Neuropixels Probes
 
-## TO DO: NEEDS FIGURES
-
 Neuropixels are silicon probes which continuously detect voltage fluctuations in the surrounding neural tissue on 374 or 384 channels (depending on the model). Each channel is split into two separate data streams, or *bands*, on the probes. The *spike band* is digitized at 30 kHz with a 500 Hz high-pass filter, and contains information about {term}`action potential`s fired by neurons directly adjacent to the probe. The *{term}`LFP` band* is digitized at 2.5 kHz, and records the low-frequency (<1000 Hz) fluctuations that result from synchronized neural activity over a wider area. The shanks are generally 10 mm long with a 70 µm width.
 
 Neuropixels 1.0 features 960 recording sites and 384 channels which can be configured for recording. In NP 1.0, the recording sites are squares with an edge length of 12 µm, arranged in four columns aligned in a staggered "checkerboard" pattern. They are positioned with approximately 20 µm center-to-center vertical spacings across a vertical span of approximately 3.8 mm. The geometry allows NP 1.0 data to cover a relatively large patch of the brain with high temporal resolution.


### PR DESCRIPTION
Removed placeholder for missing figures in the neuropixels description.